### PR TITLE
Fix hardcoded subtick behavior

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'io.github.zpiboo.mpkspeedrun'
-version = '0.3.0'
+version = '0.3.1'
 
 tasks.register('buildAll', Jar) {
     description = 'Builds and merges all modules.'

--- a/common/src/main/java/io/github/zpiboo/mpkspeedrun/Speedrunner.java
+++ b/common/src/main/java/io/github/zpiboo/mpkspeedrun/Speedrunner.java
@@ -44,7 +44,7 @@ public class Speedrunner {
     }
     public void setCurrentMap(PkMap map) {
         currentMap = map;
-        timer.setTimeInTicks(0);
+        timer.reset();
         timer.setEnabled(false);
     }
 
@@ -95,7 +95,7 @@ public class Speedrunner {
 
         boolean shouldStartMap = pkMap.getStart().tick(currentPlayer);
         if (shouldStartMap) {
-            timer.reset();
+            timer.setTimeInTicks(getCurrentMap().getStartTime());
             timer.setSubtick(-getCurrentMap().getStart().getSubtick());
             timer.setEnabled(true);
         }
@@ -132,7 +132,7 @@ public class Speedrunner {
         }
 
         public void reset() {
-            setTimeInTicks(getCurrentMap().getStartTime());
+            setTimeInTicks(0);
             setSubtick(0.0D);
         }
         public void increment() {

--- a/common/src/main/java/io/github/zpiboo/mpkspeedrun/Speedrunner.java
+++ b/common/src/main/java/io/github/zpiboo/mpkspeedrun/Speedrunner.java
@@ -102,7 +102,7 @@ public class Speedrunner {
     }
 
     @InfoString.DataClass
-    public class Timer implements FormatDecimals {
+    public static class Timer implements FormatDecimals {
         private int timeInTicks = 0;
         private double subtick = 0.0D;
         private final SubtickTimerFormat subtickTimer = new SubtickTimerFormat();

--- a/common/src/main/java/io/github/zpiboo/mpkspeedrun/Speedrunner.java
+++ b/common/src/main/java/io/github/zpiboo/mpkspeedrun/Speedrunner.java
@@ -87,11 +87,7 @@ public class Speedrunner {
             boolean shouldFinishMap = pkMap.getFinish().tick(currentPlayer);
             if (shouldFinishMap) {
                 timer.setEnabled(false);
-                timer.setSubtick(timer.getSubtick() + BB3D.slabMethod(
-                        previousPlayer.getPos(),
-                        currentPlayer.getPos(),
-                        getCurrentMap().getFinish().getBox()
-                ));
+                timer.setSubtick(timer.getSubtick() + getCurrentMap().getFinish().getSubtick());
             } else {
                 timer.increment();
             }
@@ -100,11 +96,7 @@ public class Speedrunner {
         boolean shouldStartMap = pkMap.getStart().tick(currentPlayer);
         if (shouldStartMap) {
             timer.reset();
-            timer.setSubtick(BB3D.slabMethod(
-                    currentPlayer.getPos(),
-                    previousPlayer.getPos(),
-                    getCurrentMap().getStart().getBox()
-            ) - 1);
+            timer.setSubtick(-getCurrentMap().getStart().getSubtick());
             timer.setEnabled(true);
         }
     }

--- a/common/src/main/java/io/github/zpiboo/mpkspeedrun/parkourmaps/TriggerZone.java
+++ b/common/src/main/java/io/github/zpiboo/mpkspeedrun/parkourmaps/TriggerZone.java
@@ -1,15 +1,14 @@
 package io.github.zpiboo.mpkspeedrun.parkourmaps;
 
-import java.util.Arrays;
-
-import io.github.kurrycat.mpkmod.gui.infovars.InfoString;
-import org.json.JSONObject;
-
 import io.github.kurrycat.mpkmod.compatibility.MCClasses.Player;
+import io.github.kurrycat.mpkmod.gui.infovars.InfoString;
 import io.github.kurrycat.mpkmod.util.BoundingBox3D;
 import io.github.kurrycat.mpkmod.util.Vector3D;
 import io.github.zpiboo.mpkspeedrun.MPKSpeedrun;
 import io.github.zpiboo.mpkspeedrun.util.BB3D;
+import org.json.JSONObject;
+
+import java.util.Arrays;
 
 @InfoString.DataClass
 public class TriggerZone {

--- a/common/src/main/java/io/github/zpiboo/mpkspeedrun/parkourmaps/TriggerZone.java
+++ b/common/src/main/java/io/github/zpiboo/mpkspeedrun/parkourmaps/TriggerZone.java
@@ -16,7 +16,9 @@ public class TriggerZone {
     private BoundingBox3D box;
     private TriggerMode mode;
 
-    private int triggerAirtime = 0;
+    public boolean shouldTrigger = false;
+    private int lastAirtime = 0;
+    private double lastSubtick = 0.0D;
 
     @SuppressWarnings("unused") public static final TriggerZone ZERO = new TriggerZone();
 
@@ -58,10 +60,36 @@ public class TriggerZone {
 
     @InfoString.Getter
     public int getAirtime() {
-        return triggerAirtime;
+        return lastAirtime;
     }
-    public void setAirtime(int triggerAirtime) {
-        this.triggerAirtime = triggerAirtime;
+    public void setAirtime(int airtime) {
+        lastAirtime = airtime;
+    }
+
+    public double getSubtick() {
+        return lastSubtick;
+    }
+    public void setSubtick(double subtick) {
+        lastSubtick = subtick;
+    }
+
+    private double calculateSubtick(Player player) {
+        switch (mode) {
+            case POS_ENTER:
+                return BB3D.slabMethod(
+                        player.getLastPos(),
+                        player.getPos(),
+                        getBox()
+                );
+            case POS_EXIT:
+                return 1.0D - BB3D.slabMethod(
+                        player.getPos(),
+                        player.getLastPos(),
+                        getBox()
+                );
+
+            default: return 0.0D;
+        }
     }
 
     private boolean shouldTrigger(Player player) {
@@ -88,10 +116,11 @@ public class TriggerZone {
     }
 
     public boolean tick(Player player) {
-        boolean shouldTrigger = shouldTrigger(player);
+        shouldTrigger = shouldTrigger(player);
 
         if (shouldTrigger) {
             setAirtime(player.getAirtime());
+            setSubtick(calculateSubtick(player));
         }
 
         return shouldTrigger;


### PR DESCRIPTION
- Whether trigger zones are in `EXIT` or `ENTER` mode is now taken in consideration when calculating subticks
- Switching maps now resets subticks as well

Fixes #23 